### PR TITLE
Add support for disabling CDN cache for individual files

### DIFF
--- a/.github/workflows/cdn-upload.yaml
+++ b/.github/workflows/cdn-upload.yaml
@@ -25,12 +25,12 @@ jobs:
 
       - id: timestamp
         name: set timestamp
-        run: echo "::set-output name=timestamp::$(date +'%Y-%m-%dT%H:%M%z')" >> ${GITHUB_OUTPUT}
-
+        run: |
+          echo "TIMESTAMP=$(date +'%Y-%m-%dT%H:%M%z')" >> $GITHUB_ENV
 
       - name: update index.html
         run: |
-          sed -i "s/%%TIMESTAMP%%/${{ steps.timestamp.outputs.timestamp }}/g" data/index.html
+          sed -i "s/%%TIMESTAMP%%/${{ env.TIMESTAMP }}/g" data/index.html
 
       - name: upload to cdn
         uses: ./actions/cdn-upload/v1
@@ -42,5 +42,5 @@ jobs:
 
       - name: test cdn
         run: |
-          curl -s "${url}" | grep "${{ steps.timestamp.outputs.timestamp }}"
+          curl -s $url | grep ${{ env.TIMESTAMP }}
 

--- a/.github/workflows/cdn-upload.yaml
+++ b/.github/workflows/cdn-upload.yaml
@@ -25,7 +25,8 @@ jobs:
 
       - id: timestamp
         name: set timestamp
-        run: echo "timestamp=$(date +'%Y-%m-%dT%H:%M%z')-$(git rev-parse --short HEAD)" >> ${GITHUB_ENV}
+        run: echo "::set-output name=timestamp::$(date +'%Y-%m-%dT%H:%M%z')" >> ${GITHUB_OUTPUT}
+
 
       - name: update index.html
         run: |

--- a/.github/workflows/cdn-upload.yaml
+++ b/.github/workflows/cdn-upload.yaml
@@ -20,10 +20,6 @@ jobs:
       contents: 'read'
       id-token: 'write'
 
-    defaults:
-      run:
-        working-directory: react/cdn
-
     steps:
       - uses: actions/checkout@v3
 
@@ -32,5 +28,5 @@ jobs:
           cdn-team-name: example
           source: ./data
           destination: /
-          source-keep-parent-name: true
+          no-cache-paths: data/index.html
 

--- a/.github/workflows/cdn-upload.yaml
+++ b/.github/workflows/cdn-upload.yaml
@@ -42,5 +42,5 @@ jobs:
 
       - name: test cdn
         run: |
-          curl -s $url | grep ${{ env.TIMESTAMP }}
+          curl -s https://cdn.nav.no/example/data/index.html | grep ${{ env.TIMESTAMP }}
 

--- a/.github/workflows/cdn-upload.yaml
+++ b/.github/workflows/cdn-upload.yaml
@@ -43,4 +43,5 @@ jobs:
       - name: test cdn
         run: |
           curl -s https://cdn.nav.no/example/data/index.html | grep ${{ env.TIMESTAMP }}
+          curl -sI https://cdn.nav.no/example/data/index.html | grep "cache-control: no-store"
 

--- a/.github/workflows/cdn-upload.yaml
+++ b/.github/workflows/cdn-upload.yaml
@@ -23,10 +23,29 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: ./actions/cdn-upload/v1
+      - id: timestamp
+        name: set timestamp
+        run: |
+          echo "::set-output name=timestamp::$(date +"%Y-%m-%dT%H:%M%z)" >> $GITHUB_ENV
+
+      - name: update index.html
+        run: |
+          sed -i "s/%%TIMESTAMP%%/${{ steps.timestamp.outputs.timestamp }}/g" data/index.html
+
+      - name: upload to cdn
+        uses: ./actions/cdn-upload/v1
         with:
           cdn-team-name: example
           source: ./data
           destination: /
           no-cache-paths: data/index.html
+
+      - name: test cdn
+        run: |
+          url="https://cdn.nav.no/example/data/index.html"
+          curl -s $url | grep ${{ steps.timestamp.outputs.timestamp }}
+          if [ $? -ne 0 ]; then
+            echo "timestamp not found in $url"
+            exit 1
+          fi
 

--- a/.github/workflows/cdn-upload.yaml
+++ b/.github/workflows/cdn-upload.yaml
@@ -1,0 +1,35 @@
+name: "CDN Upload"
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'actions/cdn-uplad/**'
+      - '.github/workflows/cdn-upload.yaml'
+  pull_request:
+    paths:
+      - 'actions/cdn-uplad/**'
+      - '.github/workflows/cdn-upload.yaml'
+
+jobs:
+  cdn-upload:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    defaults:
+      run:
+        working-directory: react/cdn
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ./actions/cdn-upload/v1
+        with:
+          cdn-team-name: example
+          source: ./data
+          destination: /
+

--- a/.github/workflows/cdn-upload.yaml
+++ b/.github/workflows/cdn-upload.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - id: timestamp
         name: set timestamp
-        run: echo "timestamp=$(date +'%Y-%m-%dT%H:%M%z')-$(git rev-parse --short HEAD)" >> ${GITHUB_OUTPUT}
+        run: echo "timestamp=$(date +'%Y-%m-%dT%H:%M%z')-$(git rev-parse --short HEAD)" >> ${GITHUB_ENV}
 
       - name: update index.html
         run: |

--- a/.github/workflows/cdn-upload.yaml
+++ b/.github/workflows/cdn-upload.yaml
@@ -32,4 +32,5 @@ jobs:
           cdn-team-name: example
           source: ./data
           destination: /
+          source-keep-parent-name: true
 

--- a/.github/workflows/cdn-upload.yaml
+++ b/.github/workflows/cdn-upload.yaml
@@ -25,8 +25,7 @@ jobs:
 
       - id: timestamp
         name: set timestamp
-        run: |
-          echo "::set-output name=timestamp::$(date +'%Y-%m-%dT%H:%M%z')" >> $GITHUB_ENV
+        run: echo "timestamp=$(date +'%Y-%m-%dT%H:%M%z')-$(git rev-parse --short HEAD)" >> ${GITHUB_OUTPUT}
 
       - name: update index.html
         run: |
@@ -42,10 +41,5 @@ jobs:
 
       - name: test cdn
         run: |
-          url="https://cdn.nav.no/example/data/index.html"
-          curl -s $url | grep ${{ steps.timestamp.outputs.timestamp }}
-          if [ $? -ne 0 ]; then
-            echo "timestamp not found in $url"
-            exit 1
-          fi
+          curl -s "${url}" | grep "${{ steps.timestamp.outputs.timestamp }}"
 

--- a/.github/workflows/cdn-upload.yaml
+++ b/.github/workflows/cdn-upload.yaml
@@ -26,7 +26,7 @@ jobs:
       - id: timestamp
         name: set timestamp
         run: |
-          echo "::set-output name=timestamp::$(date +"%Y-%m-%dT%H:%M%z)" >> $GITHUB_ENV
+          echo "::set-output name=timestamp::$(date +'%Y-%m-%dT%H:%M%z')" >> $GITHUB_ENV
 
       - name: update index.html
         run: |

--- a/actions/cdn-upload/v1/action.yaml
+++ b/actions/cdn-upload/v1/action.yaml
@@ -64,7 +64,7 @@ runs:
 
     # Invalidate cache if cache-invalidation is set to true
     - name: 'Set up Cloud SDK'
-      if: ${{ inputs.cache-invalidation == 'true' || ${{ inputs.no-cache-paths }} != '' }}
+      if: ${{ inputs.cache-invalidation == 'true' || ${{ inputs.no-cache-paths }} != ''
       uses: 'google-github-actions/setup-gcloud@v1'
 
     # Authenticate with Google Cloud using Workload Identity Federation

--- a/actions/cdn-upload/v1/action.yaml
+++ b/actions/cdn-upload/v1/action.yaml
@@ -62,11 +62,6 @@ runs:
         echo "BUCKET_NAME=frontend-plattform-prod-${{ inputs.cdn-team-name }}" >> $GITHUB_ENV
         echo "SA_NAME=gh-${{ inputs.cdn-team-name }}" >> $GITHUB_ENV
 
-    # Invalidate cache if cache-invalidation is set to true
-    - name: 'Set up Cloud SDK'
-      if: ${{ inputs.cache-invalidation == 'true' || inputs.no-cache-paths != '' }}
-      uses: 'google-github-actions/setup-gcloud@v1'
-
     # Authenticate with Google Cloud using Workload Identity Federation
     - id: 'auth'
       uses: 'google-github-actions/auth@v0'
@@ -84,6 +79,11 @@ runs:
         path: '${{ inputs.source }}'
         parent: '${{ inputs.source-keep-parent-name }}'
         destination: '${{ env.BUCKET_NAME }}/${{ inputs.cdn-team-name }}/${{ inputs.destination }}'
+
+    # Invalidate cache if cache-invalidation is set to true
+    - name: 'Set up Cloud SDK'
+      if: ${{ inputs.cache-invalidation == 'true' || inputs.no-cache-paths != '' }}
+      uses: 'google-github-actions/setup-gcloud@v1'
 
     - name: 'Invalidating cache'
       if: ${{ inputs.cache-invalidation == 'true' }}
@@ -115,7 +115,8 @@ runs:
               [Google Cloud Console]($console_url) → Caching or set \`cache-invalidation-background\` \
               to \`false\` in order to wait for the invalidation to complete." >> $GITHUB_STEP_SUMMARY
 
-    - if: ${{ inputs.no-cache-paths != '' }}
+    - name: Set no-cache metadata
+      if: ${{ inputs.no-cache-paths != '' }}
       shell: bash
       run: |
         paths=(${{ inputs.no-cache-paths }})

--- a/actions/cdn-upload/v1/action.yaml
+++ b/actions/cdn-upload/v1/action.yaml
@@ -64,7 +64,7 @@ runs:
 
     # Invalidate cache if cache-invalidation is set to true
     - name: 'Set up Cloud SDK'
-      if: ${{ inputs.cache-invalidation == 'true' || ${{ inputs.no-cache-paths }} != ''
+      if: ${{ inputs.cache-invalidation == 'true' || inputs.no-cache-paths != '' }}
       uses: 'google-github-actions/setup-gcloud@v1'
 
     # Authenticate with Google Cloud using Workload Identity Federation
@@ -115,7 +115,7 @@ runs:
               [Google Cloud Console]($console_url) → Caching or set \`cache-invalidation-background\` \
               to \`false\` in order to wait for the invalidation to complete." >> $GITHUB_STEP_SUMMARY
 
-    - if: ${{ inputs.no-cache-paths }} != ''
+    - if: ${{ inputs.no-cache-paths != '' }}
       shell: bash
       run: |
         paths=(${{ inputs.no-cache-paths }})

--- a/actions/cdn-upload/v1/action.yaml
+++ b/actions/cdn-upload/v1/action.yaml
@@ -26,6 +26,10 @@ inputs:
     description: 'Run cache invalidation in the background without waiting'
     required: false
     default: 'true'
+  no-cache-paths:
+    description: 'Comma separated list of paths that should not be cached'
+    required: false
+    default: ''
 
 outputs:
   uploaded:
@@ -58,6 +62,11 @@ runs:
         echo "BUCKET_NAME=frontend-plattform-prod-${{ inputs.cdn-team-name }}" >> $GITHUB_ENV
         echo "SA_NAME=gh-${{ inputs.cdn-team-name }}" >> $GITHUB_ENV
 
+    # Invalidate cache if cache-invalidation is set to true
+    - name: 'Set up Cloud SDK'
+      if: ${{ inputs.cache-invalidation == 'true' || ${{ inputs.no-cache-paths }} != '' }}
+      uses: 'google-github-actions/setup-gcloud@v1'
+
     # Authenticate with Google Cloud using Workload Identity Federation
     - id: 'auth'
       uses: 'google-github-actions/auth@v0'
@@ -75,11 +84,6 @@ runs:
         path: '${{ inputs.source }}'
         parent: '${{ inputs.source-keep-parent-name }}'
         destination: '${{ env.BUCKET_NAME }}/${{ inputs.cdn-team-name }}/${{ inputs.destination }}'
-
-    # Invalidate cache if cache-invalidation is set to true
-    - name: 'Set up Cloud SDK'
-      if: ${{ inputs.cache-invalidation == 'true' }}
-      uses: 'google-github-actions/setup-gcloud@v1'
 
     - name: 'Invalidating cache'
       if: ${{ inputs.cache-invalidation == 'true' }}
@@ -110,3 +114,13 @@ runs:
               before the cache is invalidated. You can check the status of the invalidation in \
               [Google Cloud Console]($console_url) → Caching or set \`cache-invalidation-background\` \
               to \`false\` in order to wait for the invalidation to complete." >> $GITHUB_STEP_SUMMARY
+
+    - if: ${{ inputs.no-cache-paths }} != ''
+      shell: bash
+      run: |
+        paths=(${{ inputs.no-cache-paths }})
+        IFS=','
+
+        for path in $paths; do
+          gsutil setmeta -h "Cache-Control:no-store" "gs://${BUCKET_NAME}/${{ inputs.cdn-team-name }}/$path"
+        done

--- a/data/index.html
+++ b/data/index.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+<head>
+    <title>CDN Example</title>
+
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style type="text/css">
+    body {
+        background-color: #f0f0f2;
+        margin: 0;
+        padding: 0;
+        font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+
+    }
+    div {
+        width: 600px;
+        margin: 5em auto;
+        padding: 2em;
+        background-color: #fdfdff;
+        border-radius: 0.5em;
+        box-shadow: 2px 3px 7px 2px rgba(0,0,0,0.02);
+    }
+    a:link, a:visited {
+        color: #38488f;
+        text-decoration: none;
+    }
+    @media (max-width: 700px) {
+        div {
+            margin: 0 auto;
+            width: auto;
+        }
+    }
+    </style>
+</head>
+
+<body>
+<div>
+    <h1>CDN Example</h1>
+    <p>This page is for demonstrating NAV CDN.-</p>
+</div>
+</body>
+</html>

--- a/data/index.html
+++ b/data/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-    <title>CDN Example</title>
+    <title>cdn.nav.no/example</title>
 
     <meta charset="utf-8" />
     <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
@@ -37,8 +37,9 @@
 
 <body>
 <div>
-    <h1>CDN Example</h1>
-    <p>This page is for demonstrating NAV CDN.-</p>
+    <h1>cdn.nav.no/example</h1>
+    <p>This page is for example purposes only. It is just an index.html file some text in a bucket.</p>
+    <p>Last built: %%TIMESTAMP%%</p>
 </div>
 </body>
 </html>


### PR DESCRIPTION
Add support for adding `Cache-Control:no-store` metadata for individual files
after upload.

Usage:

```yaml
jobs:
   deploy:
      - name: Upload to CDN
        uses: navikt/frontend/actions/cdn-upload/v1@main
        with:
          cdn-team-name: dab
          source: ./build/
          destination: /
          no-cache-paths: build/asset-manifest.json,build/index.html
```

Ref. discussion on Slack: https://nav-it.slack.com/archives/C02MZEY9YHY/p1692095153305669