### PR TITLE
Migrerer eksempel med dekoratoren fra v1 til v2

### DIFF
--- a/nextjs/dekoratoren/package.json
+++ b/nextjs/dekoratoren/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@navikt/nav-dekoratoren-moduler": "^1.6.18",
+    "@navikt/nav-dekoratoren-moduler": "^2",
     "next": "13.3.1",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/nextjs/dekoratoren/pages/_document.tsx
+++ b/nextjs/dekoratoren/pages/_document.tsx
@@ -6,24 +6,25 @@ import Document, {
   DocumentContext,
 } from "next/document";
 import {
-  Components,
-  Env,
+  DecoratorComponents,
+  DecoratorParams,
   fetchDecoratorReact,
-  Props,
 } from "@navikt/nav-dekoratoren-moduler/ssr";
 import React from "react";
 
-const decoratorEnv = "dev" as Exclude<Env, "localhost">;
+const decoratorEnv: "dev" | "prod" = process.env.NAIS_CLUSTER_NAME === "prod-gcp" ? "prod" : "dev";
 
-const decoratorParams: Props = {
-  env: decoratorEnv,
+const decoratorParams: DecoratorParams = {
   context: "privatperson",
 };
 
-class _Document extends Document<{ decorator: Components }> {
+class _Document extends Document<{ decorator: DecoratorComponents }> {
   static async getInitialProps(ctx: DocumentContext) {
     const initialProps = await Document.getInitialProps(ctx);
-    const decorator = await fetchDecoratorReact(decoratorParams);
+    const decorator = await fetchDecoratorReact({
+      env: decoratorEnv,
+      params: decoratorParams
+    });
     return { ...initialProps, decorator };
   }
 

--- a/nextjs/dekoratoren/pages/_document.tsx
+++ b/nextjs/dekoratoren/pages/_document.tsx
@@ -6,25 +6,24 @@ import Document, {
   DocumentContext,
 } from "next/document";
 import {
-  DecoratorComponents,
-  DecoratorParams,
+  DecoratorComponents, DecoratorFetchProps,
   fetchDecoratorReact,
 } from "@navikt/nav-dekoratoren-moduler/ssr";
 import React from "react";
 
 const decoratorEnv: "dev" | "prod" = process.env.NAIS_CLUSTER_NAME === "prod-gcp" ? "prod" : "dev";
 
-const decoratorParams: DecoratorParams = {
-  context: "privatperson",
+const decoratorProps: DecoratorFetchProps = {
+  env: decoratorEnv,
+  params: {
+    context: "privatperson",
+  }
 };
 
 class _Document extends Document<{ decorator: DecoratorComponents }> {
   static async getInitialProps(ctx: DocumentContext) {
     const initialProps = await Document.getInitialProps(ctx);
-    const decorator = await fetchDecoratorReact({
-      env: decoratorEnv,
-      params: decoratorParams
-    });
+    const decorator = await fetchDecoratorReact(decoratorProps);
     return { ...initialProps, decorator };
   }
 


### PR DESCRIPTION
Dette var en nyttig case study for min egen kodebase :)

* `Components` heter nå `DecoratorComponents`, `Props` heter nå `DecoratorParams`
* `Env` er ikke lenger eksportert, så for illustrasjonens skyld typer jeg den eksplisitt