### PR TITLE
Bump deprecated versions og cloud-storage & auth

### DIFF
--- a/actions/cdn-upload/v1/action.yaml
+++ b/actions/cdn-upload/v1/action.yaml
@@ -64,7 +64,7 @@ runs:
 
     # Authenticate with Google Cloud using Workload Identity Federation
     - id: 'auth'
-      uses: 'google-github-actions/auth@v1'
+      uses: 'google-github-actions/auth@v2'
       env:
         GCP_PROJECT_ID: ${{ env.PROJECT_ID }}
         GCP_SA_EMAIL: gh-${{ inputs.cdn-team-name }}@${{ env.PROJECT_NAME }}.iam.gserviceaccount.com
@@ -74,7 +74,7 @@ runs:
 
     # Upload files to Google Cloud Storage Bucket connected to CDN
     - id: 'upload-file'
-      uses: 'google-github-actions/upload-cloud-storage@v0'
+      uses: 'google-github-actions/upload-cloud-storage@v2'
       with:
         path: '${{ inputs.source }}'
         parent: '${{ inputs.source-keep-parent-name }}'


### PR DESCRIPTION
Får dette i CDN action, så bumpet versjonene til det som er spesifisert her https://github.com/google-github-actions/upload-cloud-storage
<img width="1125" alt="image" src="https://github.com/navikt/frontend/assets/135981901/c20c7b89-30b9-485e-a012-ce17ca768237">

Litt usikker på hvordan jeg kan teste at det funker. 
